### PR TITLE
ci: django check + migrate + tests on push/PR

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,32 +8,18 @@ on:
 
 jobs:
   check:
-    name: django check + makemigrations dry-run (Python ${{ matrix.python-version }})
+    name: django check (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.11", "3.12"]
 
-    # MySQL service for `manage.py check` to succeed against the configured backend.
-    services:
-      mysql:
-        image: mysql:8.4
-        env:
-          MYSQL_ROOT_PASSWORD: root
-          MYSQL_DATABASE: repay_sync_dev_2
-        ports: ["3306:3306"]
-        options: >-
-          --health-cmd="mysqladmin ping -h localhost"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=5
-
     env:
-      SECRET_KEY: django-insecure-ci-only-not-used-anywhere-real
+      SECRET_KEY: ci-only-not-a-real-secret
       DEBUG: "True"
       LOGGING_DB_ENABLED: "False"
-      DB_NAME: repay_sync_dev_2
+      DB_NAME: repay_sync
       DB_USER: root
       DB_PASSWORD: root
       DB_HOST: 127.0.0.1
@@ -56,14 +42,5 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
-      - name: Django system check (no models DB needed)
+      - name: Django system check (no DB connection needed for static checks)
         run: python manage.py check
-
-      - name: Migrate
-        run: python manage.py migrate --noinput
-
-      - name: makemigrations is up to date (no drift)
-        run: python manage.py makemigrations --check --dry-run
-
-      - name: Run tests
-        run: python manage.py test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,69 @@
+name: test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  check:
+    name: django check + makemigrations dry-run (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+
+    # MySQL service for `manage.py check` to succeed against the configured backend.
+    services:
+      mysql:
+        image: mysql:8.4
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: repay_sync_dev_2
+        ports: ["3306:3306"]
+        options: >-
+          --health-cmd="mysqladmin ping -h localhost"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
+    env:
+      SECRET_KEY: django-insecure-ci-only-not-used-anywhere-real
+      DEBUG: "True"
+      LOGGING_DB_ENABLED: "False"
+      DB_NAME: repay_sync_dev_2
+      DB_USER: root
+      DB_PASSWORD: root
+      DB_HOST: 127.0.0.1
+      DB_PORT: "3306"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: System deps for mysqlclient
+        run: sudo apt-get update && sudo apt-get install -y default-libmysqlclient-dev pkg-config
+
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Django system check (no models DB needed)
+        run: python manage.py check
+
+      - name: Migrate
+        run: python manage.py migrate --noinput
+
+      - name: makemigrations is up to date (no drift)
+        run: python manage.py makemigrations --check --dry-run
+
+      - name: Run tests
+        run: python manage.py test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # repay_sync
 
+[![test](https://github.com/prajwalmahajan101/repay_sync/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/prajwalmahajan101/repay_sync/actions/workflows/test.yml)
+
 A small Django 5 + DRF service exploring the data model and workflow behind loan-repayment collection — the operational layer collection officers and supervisors actually use.
 
 ## What it covers


### PR DESCRIPTION
## Summary
Adds CI to repay_sync — runs the Django system check, migrations, drift check, and test suite against a real MySQL 8.4 service container.

## What runs
- `python manage.py check`
- `python manage.py migrate --noinput` (boots the schema)
- `python manage.py makemigrations --check --dry-run` (fails if a model change is missing a migration)
- `python manage.py test` (runs per-app `tests.py` files)

## Matrix
- Python 3.11
- Python 3.12

## Why a real MySQL
`repay_sync/settings.py` is hardcoded to the MySQL backend (mysqlclient). Running CI against SQLite would either need a settings override file or hide MySQL-specific issues. A service container is the lower-friction choice and matches the production engine.

## Test plan
- [ ] CI passes on this branch on Python 3.11 and 3.12
- [ ] Badge renders green once merged
- [ ] If migrations drift on a future PR, `makemigrations --check` catches it