### PR TITLE
docs: relabel as exploration repo + scoped CI note

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![test](https://github.com/prajwalmahajan101/repay_sync/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/prajwalmahajan101/repay_sync/actions/workflows/test.yml)
 
+> **Scope: exploration repo.** This sketches the data model and workflow for loan-repayment collection — typed dispositions, audit log, RBAC — at a level useful to *show the shape* of the problem. The production version of this domain lives in private work systems at Optimo Capitals. Don't fork this for a real service; treat it as an annotated reference.
+
 A small Django 5 + DRF service exploring the data model and workflow behind loan-repayment collection — the operational layer collection officers and supervisors actually use.
 
 ## What it covers
@@ -40,4 +42,12 @@ API root: `http://localhost:8000/api/` (JWT obtain at `/api/token/`, refresh at 
 
 ## Status
 
-Personal exploration repo — the production version of this domain lives in private work systems.
+Personal exploration repo — the production version of this domain lives in private work systems at Optimo Capitals. No release tag is cut because there is no installable artifact to version; the repo is a frozen-in-time annotated reference, not a starter.
+
+### Scoped-down CI
+
+CI runs `python manage.py check` only — settings + imports + URL conf. The four per-app `tests.py` files are not run because a pre-existing migration-ordering bug (MySQL error 1824, `users_user` referenced before defined) breaks the migrate step. Fixing the FK order is queued, but until it lands, the green badge means "settings parse," not "tests pass."
+
+### Won't ship as a starter
+
+If you want a real Django/DRF starter for a production service, use [`django_boilerplate`](https://github.com/prajwalmahajan101/django_boilerplate) instead — that one is CI-gated, tagged at [`v0.1.0`](https://github.com/prajwalmahajan101/django_boilerplate/releases/tag/v0.1.0), and shipped with a resilience layer, RBAC, JWT, and Postgres rather than the MySQL + minimal-auth setup here.


### PR DESCRIPTION
## Summary
AI-3 from the tagging audit. The repo is exploration-only — no release tag is appropriate because there's no installable artifact to version. Make the scope explicit in the README so a visitor doesn't fork this expecting a starter.

## Changes
1. **Top-of-README callout** — names the repo's scope and points to \`django_boilerplate\` for a production starter.
2. **Status section** — names the production system (Optimo Capitals), documents why CI is scoped to \`manage.py check\` (pre-existing migration FK order bug), and the won't-ship-as-starter contract.

## Test plan
- [ ] README renders cleanly on GitHub
- [ ] CI passes (no code changes; docs-only)